### PR TITLE
SAPI-270: return to client missing parameters if any

### DIFF
--- a/lib/server/endpoints/applications.js
+++ b/lib/server/endpoints/applications.js
@@ -15,23 +15,15 @@
 var assert = require('assert-plus');
 var restify = require('restify');
 
+var validateParamsAndSendError =
+    require('./validation').validateParamsAndSendError;
+
 function Applications() {}
 
-function isValidApplication(app) {
-    var valid = true;
-
-    if (!app)
-        return (false);
-
-    valid = valid && app.name;
-    valid = valid && app.owner_uuid;
-
-    return (valid);
-}
+var APPLICATION_KEYS = ['name', 'owner_uuid'];
 
 Applications.create = function (req, res, next) {
     var model = this.model;
-    var log = model.log;
 
     var params = {};
     params.uuid = req.params.uuid;
@@ -46,9 +38,11 @@ Applications.create = function (req, res, next) {
 
     params.master = req.params.master;
 
-    if (!isValidApplication(params)) {
-        log.error({ params: params }, 'missing required parameters');
-        return (next(new restify.MissingParameterError()));
+    if (validateParamsAndSendError({ req: req, res: res, next: next,
+                                     keys: APPLICATION_KEYS,
+                                     params: params }))
+    {
+        return;
     }
 
     model.createApplication(params, function (err, app) {

--- a/lib/server/endpoints/applications.js
+++ b/lib/server/endpoints/applications.js
@@ -38,10 +38,11 @@ Applications.create = function (req, res, next) {
 
     params.master = req.params.master;
 
-    if (validateParamsAndSendError({ req: req, res: res, next: next,
-                                     keys: APPLICATION_KEYS,
-                                     params: params }))
-    {
+    var valError = validateParamsAndSendError(
+        { keys: APPLICATION_KEYS,
+          params: params });
+    if (valError) {
+        next(valError);
         return;
     }
 

--- a/lib/server/endpoints/history.js
+++ b/lib/server/endpoints/history.js
@@ -35,10 +35,11 @@ History.create = function (req, res, next) {
     params.params = req.params.params;
 
 
-    if (validateParamsAndSendError({ req: req, res: res, next: next,
-                                     keys: HISTORY_KEYS,
-                                     params: params }))
-    {
+    var valError = validateParamsAndSendError(
+        { keys: HISTORY_KEYS,
+          params: params });
+    if (valError) {
+        next(valError);
         return;
     }
 

--- a/lib/server/endpoints/history.js
+++ b/lib/server/endpoints/history.js
@@ -16,25 +16,15 @@ var util = require('util');
 var assert = require('assert-plus');
 var restify = require('restify');
 
+var validateParamsAndSendError =
+    require('./validation').validateParamsAndSendError;
+
 function History() {}
 
-function isValidHistory(item) {
-    var valid = true;
-
-    if (!item) {
-        return (false);
-    }
-
-    valid = valid && item.started;
-    valid = valid && item.changes;
-    valid = valid && item.uuid;
-
-    return (valid);
-}
+var HISTORY_KEYS = ['started', 'changes', 'uuid'];
 
 History.create = function (req, res, next) {
     var model = this.model;
-    var log = model.log;
 
     var params = {};
     params.uuid = req.params.uuid;
@@ -45,9 +35,11 @@ History.create = function (req, res, next) {
     params.params = req.params.params;
 
 
-    if (!isValidHistory(params)) {
-        log.error({ params: params }, 'missing required parameters');
-        return (next(new restify.MissingParameterError()));
+    if (validateParamsAndSendError({ req: req, res: res, next: next,
+                                     keys: HISTORY_KEYS,
+                                     params: params }))
+    {
+        return;
     }
 
     model.createHistory(params, function (err, app) {

--- a/lib/server/endpoints/instances.js
+++ b/lib/server/endpoints/instances.js
@@ -17,19 +17,13 @@ var async = require('async');
 var restify = require('restify');
 
 var semverGter = require('../../common/util').semverGter;
+var validateParamsAndSendError =
+    require('./validation').validateParamsAndSendError;
 
 function Instances() {}
 
-function isValidInstance(instance) {
-    var valid = true;
+var INSTANCE_KEYS = ['server_uuid'];
 
-    if (!instance)
-        return (false);
-
-    valid = valid && instance.service_uuid;
-
-    return (valid);
-}
 
 /*
  * accept-version aware instance object representation. Make sure to include any
@@ -101,9 +95,11 @@ Instances.create = function (req, res, next) {
 
     params.master = req.params.master;
 
-    if (!isValidInstance(params)) {
-        log.error({ params: params }, 'missing required parameters');
-        return (next(new restify.MissingParameterError()));
+    if (validateParamsAndSendError({ req: req, res: res, next: next,
+                                     keys: INSTANCE_KEYS,
+                                     params: params }))
+    {
+        return;
     }
 
     model.createInstance(params, function (err, inst) {

--- a/lib/server/endpoints/instances.js
+++ b/lib/server/endpoints/instances.js
@@ -95,10 +95,11 @@ Instances.create = function (req, res, next) {
 
     params.master = req.params.master;
 
-    if (validateParamsAndSendError({ req: req, res: res, next: next,
-                                     keys: INSTANCE_KEYS,
-                                     params: params }))
-    {
+    var valError = validateParamsAndSendError(
+        { keys: INSTANCE_KEYS,
+          params: params });
+    if (valError) {
+        next(valError);
         return;
     }
 

--- a/lib/server/endpoints/manifests.js
+++ b/lib/server/endpoints/manifests.js
@@ -17,20 +17,12 @@ var assert = require('assert-plus');
 var restify = require('restify');
 var semver = require('semver');
 
+var validateParamsAndSendError =
+    require('./validation').validateParamsAndSendError;
+
 function Manifests() {}
 
-function isValidManifest(mfest) {
-    var valid = true;
-
-    if (!mfest)
-        return (false);
-
-    valid = valid && mfest.name;
-    valid = valid && mfest.path;
-    valid = valid && mfest.template;
-
-    return (valid);
-}
+var MANIFEST_KEYS = ['name', 'path', 'template'];
 
 Manifests.create = function (req, res, next) {
     var model = this.model;
@@ -47,9 +39,11 @@ Manifests.create = function (req, res, next) {
 
     params.master = req.params.master;
 
-    if (!isValidManifest(params)) {
-        log.error({ params: params }, 'missing required parameters');
-        return (next(new restify.MissingParameterError()));
+    if (validateParamsAndSendError({ req: req, res: res, next: next,
+                                     keys: MANIFEST_KEYS,
+                                     params: params }))
+    {
+        return;
     }
 
     if (params.version && !semver.valid(params.version)) {

--- a/lib/server/endpoints/manifests.js
+++ b/lib/server/endpoints/manifests.js
@@ -39,10 +39,11 @@ Manifests.create = function (req, res, next) {
 
     params.master = req.params.master;
 
-    if (validateParamsAndSendError({ req: req, res: res, next: next,
-                                     keys: MANIFEST_KEYS,
-                                     params: params }))
-    {
+    var valError = validateParamsAndSendError(
+        { keys: MANIFEST_KEYS,
+          params: params });
+    if (valError) {
+        next(valError);
         return;
     }
 

--- a/lib/server/endpoints/services.js
+++ b/lib/server/endpoints/services.js
@@ -75,10 +75,11 @@ Services.create = function (req, res, next) {
     params.master = req.params.master;
     params.type = req.params.type;
 
-    if (validateParamsAndSendError({ req: req, res: res, next: next,
-                                     keys: SERVICE_KEYS,
-                                     params: params }))
-    {
+    var valError = validateParamsAndSendError(
+        { keys: SERVICE_KEYS,
+          params: params });
+    if (valError) {
+        next(valError);
         return;
     }
 

--- a/lib/server/endpoints/services.js
+++ b/lib/server/endpoints/services.js
@@ -9,27 +9,20 @@
  */
 
 /*
- * lib/endpoints/services.js: SAPI endpoints to manage services
+ * lib/server/endpoints/services.js: SAPI endpoints to manage services
  */
 
 var assert = require('assert-plus');
 var restify = require('restify');
 
 var semverGter = require('../../common/util').semverGter;
+var validateParamsAndSendError =
+    require('./validation').validateParamsAndSendError;
 
 function Services() {}
 
-function isValidService(svc) {
-    var valid = true;
+var SERVICE_KEYS = ['name', 'application_uuid'];
 
-    if (!svc)
-        return (false);
-
-    valid = valid && svc.name;
-    valid = valid && svc.application_uuid;
-
-    return (valid);
-}
 
 /*
  * accept-version aware service object representation. Make sure to include any
@@ -68,7 +61,6 @@ function addVersionFilters(filters, version) {
 
 Services.create = function (req, res, next) {
     var model = this.model;
-    var log = model.log;
 
     var params = {};
     params.uuid = req.params.uuid;
@@ -83,9 +75,11 @@ Services.create = function (req, res, next) {
     params.master = req.params.master;
     params.type = req.params.type;
 
-    if (!isValidService(params)) {
-        log.error({ params: params }, 'missing required parameters');
-        return (next(new restify.MissingParameterError()));
+    if (validateParamsAndSendError({ req: req, res: res, next: next,
+                                     keys: SERVICE_KEYS,
+                                     params: params }))
+    {
+        return;
     }
 
     model.createService(params, function (err, svc) {

--- a/lib/server/endpoints/validation.js
+++ b/lib/server/endpoints/validation.js
@@ -17,17 +17,11 @@ var restify = require('restify');
 
 
 function validateParamsAndSendError(opts) {
-    var req = opts.req;
-    var res = opts.res;
     var keys = opts.keys;
     var params = opts.params;
-    var next = opts.next;
 
-    assert.object(req, 'opts.req');
-    assert.object(res, 'opts.res');
-    assert.object(keys, 'opts.keys');
+    assert.arrayOfString(keys, 'opts.keys');
     assert.object(params, 'opts.params');
-    assert.func(next, 'opts.next');
 
     var missing = keys.filter(function (k) {
         return (!params.hasOwnProperty(k) ||
@@ -35,11 +29,9 @@ function validateParamsAndSendError(opts) {
     });
 
     if (missing.length) {
-        next(new restify.MissingParameterError(
-            'missing required keys: %s', missing.join(', ')));
+        return new restify.MissingParameterError(
+            'missing required keys: %s', missing.join(', '));
     }
-
-    return (missing.length !== 0);
 }
 
 module.exports = {

--- a/lib/server/endpoints/validation.js
+++ b/lib/server/endpoints/validation.js
@@ -1,0 +1,47 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Copyright (c) 2014, Joyent, Inc.
+ */
+
+/*
+ * lib/server/endpoints/validation.js: SAPI endpoint paramter validation
+ */
+
+var assert = require('assert-plus');
+var restify = require('restify');
+
+
+function validateParamsAndSendError(opts) {
+    var req = opts.req;
+    var res = opts.res;
+    var keys = opts.keys;
+    var params = opts.params;
+    var next = opts.next;
+
+    assert.object(req, 'opts.req');
+    assert.object(res, 'opts.res');
+    assert.object(keys, 'opts.keys');
+    assert.object(params, 'opts.params');
+    assert.func(next, 'opts.next');
+
+    var missing = keys.filter(function (k) {
+        return (!params.hasOwnProperty(k) ||
+                  typeof (params[k]) === 'undefined');
+    });
+
+    if (missing.length) {
+        next(new restify.MissingParameterError(
+            'missing required keys: %s', missing.join(', ')));
+    }
+
+    return (missing.length !== 0);
+}
+
+module.exports = {
+    validateParamsAndSendError: validateParamsAndSendError
+};


### PR DESCRIPTION
When SAPI indicates a required parameter is missing, it doesn't say what it is. This PR breaks up some of the code into a very simple validation function and list of required params per endpoint that uses validation.

```
HTTP/1.1 409 Conflict
content-type: application/json
content-length: 40

{
  "code": "MissingParameter",
  "message": ""
}
```
